### PR TITLE
Update get-primitive for modern versions of spglib

### DIFF
--- a/mctools/generic/get_primitive.py
+++ b/mctools/generic/get_primitive.py
@@ -58,28 +58,26 @@ def get_primitive(input_file='POSCAR',
         verbose = True
 
     if verbose:
-
         def vprint(*args):
             for arg in args:
                 print(arg,)
             print("")
     else:
-
         def vprint(*args):
             pass
 
     atoms = ase.io.read(input_file, format=input_format)
-    cell = (atoms.cell.array, atoms.get_scaled_positions(), atoms.numbers)
+    atoms_spglib = (atoms.cell.array, atoms.get_scaled_positions(), atoms.numbers)
 
     vprint(
         "# Space group: ",
         str(
             spglib.get_spacegroup(
-                cell, symprec=threshold, angle_tolerance=angle_tolerance)),
+                atoms_spglib, symprec=threshold, angle_tolerance=angle_tolerance)),
         '\n')
 
     cell, positions, atomic_numbers = spglib.find_primitive(
-        A, symprec=threshold, angle_tolerance=angle_tolerance)
+        atoms_spglib, symprec=threshold, angle_tolerance=angle_tolerance)
 
     if positions is None:
         print("This space group doesn't have a more primitive unit cell.")

--- a/mctools/generic/get_primitive.py
+++ b/mctools/generic/get_primitive.py
@@ -58,6 +58,14 @@ def main():
         action="store_true",
         help="Print output to screen even when writing to file.",
     )
+    parser.add_argument(
+        "-p",
+        "--precision",
+        type=int,
+        help=("Number of decimal places for float display. "
+              "(Output files are not affected)"),
+        default=6,
+    )
     args = parser.parse_args()
 
     get_primitive(**snake_case_args(vars(args)))
@@ -74,38 +82,50 @@ def get_primitive(input_file='POSCAR',
                   output_format=None,
                   threshold=1e-5,
                   angle_tolerance=-1.,
-                  verbose=False):
+                  verbose=False,
+                  precision=6):
 
     if output_file is None:
         verbose = True
 
     if verbose:
+
         def vprint(*args):
             for arg in args:
-                print(arg,)
+                print(arg, end="")
             print("")
+
     else:
+
         def vprint(*args):
             pass
 
-    atoms = ase.io.read(input_file, format=input_format)
-    atoms_spglib = (atoms.cell.array, atoms.get_scaled_positions(), atoms.numbers)
+    float_format_str = f"{{:{precision+4}.{precision}f}}"
 
-    vprint(
-        "# Space group: ",
-        str(
-            spglib.get_spacegroup(
-                atoms_spglib, symprec=threshold, angle_tolerance=angle_tolerance)),
-        '\n')
+    def format_float(x: float) -> str:
+        return float_format_str.format(x)
+
+    atoms = ase.io.read(input_file, format=input_format)
+    atoms_spglib = (
+        atoms.cell.array,
+        atoms.get_scaled_positions(),
+        atoms.numbers,
+    )
+
+    spacegroup = spglib.get_spacegroup(
+        atoms_spglib, symprec=threshold, angle_tolerance=angle_tolerance)
+    vprint(f"Space group: {spacegroup}")
 
     cell, positions, atomic_numbers = spglib.find_primitive(
         atoms_spglib, symprec=threshold, angle_tolerance=angle_tolerance)
 
     vprint("Primitive cell vectors:")
-    vprint(cell, '\n')
+    for row in cell:
+        vprint(' '.join(map(format_float, row)))
+
     vprint("Atomic positions and proton numbers:")
     for position, number in zip(positions, atomic_numbers):
-        vprint(position, '\t', number)
+        vprint(' '.join(map(format_float, position)), '\t', number)
 
     if output_file is None:
         pass

--- a/mctools/generic/get_primitive.py
+++ b/mctools/generic/get_primitive.py
@@ -1,4 +1,5 @@
 import argparse
+from typing import Any, Dict
 
 import ase
 import ase.io
@@ -7,43 +8,64 @@ import spglib
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Find a primitive unit cell using pyspglib")
+        description="Find a primitive unit cell using spglib")
     parser.add_argument(
-        'input_file',
+        "input_file",
         type=str,
-        default='POSCAR',
-        help="Path to crystal structure file, recognisable by ASE")
+        default="POSCAR",
+        help="Path to crystal structure file, recognisable by ASE",
+    )
     parser.add_argument(
-        '--input_format',
+        "--input-format",
+        dest="input_format",
         type=str,
-        help="Format for input file (needed if ASE can't guess from filename)")
+        help="Format for input file (needed if ASE can't guess from filename)",
+    )
     parser.add_argument(
-        '-t',
-        '--threshold',
+        "-t",
+        "--threshold",
         type=float,
         default=1e-05,
-        help=("Distance threshold in AA for symmetry reduction "
-              "(corresponds to spglib 'symprec' keyword)"))
+        help=(
+            "Distance threshold in AA for symmetry reduction "
+            "(corresponds to spglib 'symprec' keyword)"
+        ),
+    )
     parser.add_argument(
-        '-a',
-        '--angle_tolerance',
+        "-a",
+        "--angle-tolerance",
+        dest="angle_tolerance",
         type=float,
         default=-1.0,
-        help="Angle tolerance for symmetry reduction")
+        help="Angle tolerance for symmetry reduction",
+    )
     parser.add_argument(
-        '-o', '--output_file', default=None, help="Path/filename for output")
+        "-o",
+        "--output-file",
+        default=None,
+        dest="output_file",
+        help="Path/filename for output",
+    )
     parser.add_argument(
-        '--output_format',
+        "--output-format",
+        dest="output_format",
         type=str,
-        help="Format for input file (needed if ASE can't guess from filename)")
+        help="Format for input file (needed if ASE can't guess from filename)",
+    )
     parser.add_argument(
-        '-v',
-        '--verbose',
+        "-v",
+        "--verbose",
         action="store_true",
-        help="Print output to screen even when writing to file.")
+        help="Print output to screen even when writing to file.",
+    )
     args = parser.parse_args()
 
-    get_primitive(**vars(args))
+    get_primitive(**snake_case_args(vars(args)))
+
+
+def snake_case_args(kwarg_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert user-friendly hyphenated arguments to python_friendly ones"""
+    return {key.replace("-", "_"): value for key, value in kwarg_dict.items()}
 
 
 def get_primitive(input_file='POSCAR',

--- a/mctools/generic/get_primitive.py
+++ b/mctools/generic/get_primitive.py
@@ -1,13 +1,13 @@
-import argparse
-from typing import Any, Dict
+from argparse import ArgumentParser
+from typing import Any, Dict, List, Optional
 
 import ase
 import ase.io
 import spglib
 
 
-def main():
-    parser = argparse.ArgumentParser(
+def get_parser() -> ArgumentParser:
+    parser = ArgumentParser(
         description="Find a primitive unit cell using spglib")
     parser.add_argument(
         "input_file",
@@ -50,6 +50,7 @@ def main():
         "--output-format",
         dest="output_format",
         type=str,
+        default=None,
         help="Format for input file (needed if ASE can't guess from filename)",
     )
     parser.add_argument(
@@ -66,7 +67,16 @@ def main():
               "(Output files are not affected)"),
         default=6,
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main(params: Optional[List[str]] = None):
+    parser = get_parser()
+
+    if params:
+        args = parser.parse_args(params)
+    else:
+        args = parser.parse_args()
 
     get_primitive(**snake_case_args(vars(args)))
 

--- a/mctools/generic/get_primitive.py
+++ b/mctools/generic/get_primitive.py
@@ -79,23 +79,19 @@ def get_primitive(input_file='POSCAR',
     cell, positions, atomic_numbers = spglib.find_primitive(
         atoms_spglib, symprec=threshold, angle_tolerance=angle_tolerance)
 
-    if positions is None:
-        print("This space group doesn't have a more primitive unit cell.")
+    vprint("Primitive cell vectors:")
+    vprint(cell, '\n')
+    vprint("Atomic positions and proton numbers:")
+    for position, number in zip(positions, atomic_numbers):
+        vprint(position, '\t', number)
 
+    if output_file is None:
+        pass
     else:
-        vprint("Primitive cell vectors:")
-        vprint(cell, '\n')
-        vprint("Atomic positions and proton numbers:")
-        for position, number in zip(positions, atomic_numbers):
-            vprint(position, '\t', number)
+        atoms = ase.Atoms(
+            scaled_positions=positions,
+            cell=cell,
+            numbers=atomic_numbers,
+            pbc=True)
 
-        if output_file is None:
-            pass
-        else:
-            atoms = ase.Atoms(
-                scaled_positions=positions,
-                cell=cell,
-                numbers=atomic_numbers,
-                pbc=True)
-
-            atoms.write(output_file, format=output_format)
+        atoms.write(output_file, format=output_format)

--- a/mctools/generic/get_primitive.py
+++ b/mctools/generic/get_primitive.py
@@ -68,19 +68,14 @@ def get_primitive(input_file='POSCAR',
         def vprint(*args):
             pass
 
-    try:
-        if input_format is None:
-            A = ase.io.read(input_file)
-        else:
-            A = ase.io.read(input_file, format=input_format)
-    except IOError as e:
-        raise Exception("I/O error({0}): {1}".format(e.errno, e.strerror))
+    atoms = ase.io.read(input_file, format=input_format)
+    cell = (atoms.cell.array, atoms.get_scaled_positions(), atoms.numbers)
 
     vprint(
         "# Space group: ",
         str(
             spglib.get_spacegroup(
-                A, symprec=threshold, angle_tolerance=angle_tolerance)),
+                cell, symprec=threshold, angle_tolerance=angle_tolerance)),
         '\n')
 
     cell, positions, atomic_numbers = spglib.find_primitive(

--- a/mctools/generic/get_primitive.py
+++ b/mctools/generic/get_primitive.py
@@ -97,12 +97,5 @@ def get_primitive(input_file='POSCAR',
                 cell=cell,
                 numbers=atomic_numbers,
                 pbc=True)
-            if output_format is None:
-                try:
-                    atoms.write(output_file, vasp5=True)
-                except TypeError:
-                    atoms.write(output_file)
-            elif output_format == "vasp":
-                atoms.write(output_file, format="vasp", vasp5=True)
-            else:
-                atoms.write(output_file, format=output_format)
+
+            atoms.write(output_file, format=output_format)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Repository = "https://github.com/ajjackson/mctools"
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"]}
 
+[tool.black]
+line-length = 79
+
 [project.scripts]
 fold-prim = "mctools.generic.fold_prim:main"
 get-energy = "mctools.generic.get_energy:main"

--- a/tests/test_get_primitive.py
+++ b/tests/test_get_primitive.py
@@ -32,8 +32,9 @@ REF_POSCAR = textwrap.dedent(
        1
     Cartesian
       1.8050080045893520  1.8050080045893520  1.8050080045893520
-    """
+    """  # noqa:W291
 )
+
 
 @pytest.fixture
 def rattled_cu() -> ase.Atoms:
@@ -44,6 +45,7 @@ def rattled_cu() -> ase.Atoms:
     atoms.set_cell(atoms.cell.array + 1e-4 * rng.rand(3, 3))
 
     return atoms
+
 
 def test_get_primitive(rattled_cu, tmp_path, capsys) -> None:
     rattled_cu.write(tmp_path / FILENAME)

--- a/tests/test_get_primitive.py
+++ b/tests/test_get_primitive.py
@@ -1,0 +1,65 @@
+import textwrap
+
+import ase
+import ase.build
+from numpy.random import RandomState
+import pytest
+
+from mctools.generic.get_primitive import main
+
+
+FILENAME = "rattled_cu.extxyz"
+OUTFILENAME = "POSCAR"
+REF_STDOUT = textwrap.dedent(
+    """\
+    Space group: Fm-3m (225)
+    Primitive cell vectors:
+      0.000   1.805   1.805
+      1.805   0.000   1.805
+      1.805   1.805   0.000
+    Atomic positions and proton numbers:
+      0.500   0.500   0.500\t29
+    """
+)
+REF_POSCAR = textwrap.dedent(
+    """\
+    Cu 
+     1.0000000000000000
+         0.0000000000000000    1.8050080045893520    1.8050080045893520
+         1.8050080045893520    0.0000000000000000    1.8050080045893520
+         1.8050080045893520    1.8050080045893520    0.0000000000000000
+     Cu 
+       1
+    Cartesian
+      1.8050080045893520  1.8050080045893520  1.8050080045893520
+    """
+)
+
+@pytest.fixture
+def rattled_cu() -> ase.Atoms:
+    rng = RandomState(seed=1)
+
+    atoms = ase.build.bulk("Cu", cubic=True) * (2, 2, 2)
+    atoms.rattle(stdev=1e-3, seed=1)
+    atoms.set_cell(atoms.cell.array + 1e-4 * rng.rand(3, 3))
+
+    return atoms
+
+def test_get_primitive(rattled_cu, tmp_path, capsys) -> None:
+    rattled_cu.write(tmp_path / FILENAME)
+
+    main([str(tmp_path / FILENAME),
+          "--input-format=extxyz",
+          "--threshold=1e-2",
+          "--angle-tolerance=1",
+          "-o",
+          str(tmp_path / OUTFILENAME),
+          "-v",
+          "--precision=3"
+          ])
+
+    captured = capsys.readouterr()
+    assert captured.out == REF_STDOUT
+
+    with open(tmp_path / OUTFILENAME, "r") as fd:
+        assert fd.read() == REF_POSCAR

--- a/tests/test_get_spacegroup.py
+++ b/tests/test_get_spacegroup.py
@@ -26,7 +26,7 @@ REF_TEXT = textwrap.dedent(
 )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def symmetry_broken_cu() -> ase.Atoms:
     atoms = ase.build.bulk("Cu", cubic=True) * (2, 2, 2)
 


### PR DESCRIPTION
Closes #3 

- spglib no longer supports Atoms as input
- while we are here, modernise the input arguments a bit
- make the printed output cleaner
- remove some vasp5-related logic that is no longer needed.

### TODO
- [x] Unit test
