### PR TITLE
Set lint failure threshold, run on 3.11 only

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -21,4 +21,4 @@ jobs:
         pip install .
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files 'mctools/*.py')
+        pylint $(git ls-files 'mctools/*.py') --fail-under 8.1


### PR DESCRIPTION
Closes #8 

Running on 3.9 and 3.11 was useful when checking the package would install succesfully; the pytest run is now responsible for that.

The Pylint runner does still need to install mctools with dependencies, in order to check for import errors.